### PR TITLE
chore: add scripts to run lighthouse reports for all available pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
+
+lighthouse-reports
+lighthouse-pages.json

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,5 +3,23 @@
  *
  * See: https://www.gatsbyjs.org/docs/node-apis/
  */
+const fs = require("fs")
+const ignorePages = ["/404/"]
 
-// You can delete this file if you're not using it
+exports.onPostBuild = async function onPostBuild({ cache, store, graphql }) {
+  const { data } = await graphql(allPages)
+  const pagesToCheck = data.allSitePage.nodes
+    .map(e => e.path)
+    .filter(url => !url.match(/\/dev-/) && !ignorePages.includes(url))
+  fs.writeFileSync("./lighthouse-pages.json", JSON.stringify(pagesToCheck))
+}
+
+const allPages = `
+  query allSites {
+    allSitePage {
+      nodes {
+        path
+      }
+    }
+  }
+`

--- a/lighthouse/manifest.js
+++ b/lighthouse/manifest.js
@@ -1,0 +1,56 @@
+// This file contains a manifest detailing which tests lighthouse should perform
+const pages = require("../lighthouse-pages.json")
+
+const defaultThresholds = {
+  performance: 1.0,
+  pwa: 0.0,
+  accessibility: 1.0,
+  "best-practices": 1.0,
+  seo: 1.0,
+}
+
+const localAuditsToSkip = ["is-on-https", "uses-http2", "robots-txt"]
+const publicAuditsToSkip = []
+const publicConfig = {
+  extends: "lighthouse:default",
+  settings: {
+    skipAudits: publicAuditsToSkip,
+    onlyCategories: ["accessibility", "best-practices", "seo"],
+  },
+}
+const localConfig = {
+  extends: "lighthouse:default",
+  settings: {
+    skipAudits: localAuditsToSkip,
+    onlyCategories: ["accessibility", "best-practices", "seo"],
+  },
+}
+
+const singleRunPaths = ["/"]
+const allPaths = pages
+
+const pathsThresholdsOverride = {
+  "/": {},
+}
+
+const getSpecificThreshold = path => {
+  return pathsThresholdsOverride[path] || {}
+}
+
+module.exports = {
+  single: singleRunPaths.map(path => ({
+    path,
+    thresholds: { ...defaultThresholds, ...getSpecificThreshold(path) },
+    config: localConfig,
+  })),
+  local: allPaths.map(path => ({
+    path,
+    thresholds: { ...defaultThresholds, ...getSpecificThreshold(path) },
+    config: { ...localConfig },
+  })),
+  public: allPaths.map(path => ({
+    path,
+    thresholds: { ...defaultThresholds, ...getSpecificThreshold(path) },
+    config: { ...publicConfig },
+  })),
+}

--- a/lighthouse/runner.js
+++ b/lighthouse/runner.js
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+/*
+ * General configuration
+ */
+const config = {
+    waiting: {
+      interval: 0.5, // 0.5s
+      timeout: 10, // 10s
+    },
+    output: {
+      reportDirectory: "./lighthouse-reports",
+      reportPrefix: "report-",
+    },
+  }
+  
+  /*
+   * Imports
+   */
+  const waitUntil = require("wait-until")
+  const validUrl = require("valid-url")
+  const axios = require("axios")
+  const path = require("path")
+  const lighthouse = require("lighthouse")
+  const puppeteer = require("puppeteer")
+  const request = require("request")
+  const cookie = require("cookie")
+  const util = require("util")
+  const chromeLauncher = require("chrome-launcher")
+  const url = require("url")
+  const _ = require("lodash")
+  const table = require("table")
+  const colors = require("colors")
+  const fs = require("fs-extra")
+  const filenamify = require("filenamify")
+  const log = require("lighthouse-logger")
+  
+  /*
+   * Input processing
+   */
+  
+  // load our manifest
+  let manifest
+  try {
+    manifest = require(path.join("..", process.argv[2]))
+  } catch (err) {
+    throw new Error("Please pass in a valid manifest path.")
+  }
+  
+  // ensure that URL is well formed
+  const baseUrl = process.argv[3]
+  if (!validUrl.isWebUri(baseUrl)) {
+    throw new Error("Please pass in a valid URL.")
+  }
+  
+  // ensure that the test-group exists in the manifest
+  const testGroup = manifest[process.argv[4]]
+  if (!testGroup) {
+    throw new Error(
+      "Please pass in a valid test group, that exists in your manifest."
+    )
+  }
+  
+  // parse lighthouse headers
+  let headers = {}
+  try {
+    headers = JSON.parse(process.argv[5])
+  } catch (err) {
+    //noop
+  }
+  headers["Accept-Language"] = "en" // otherwise will spam console.logs with 404 and locale not found from API if your browser has its primary lang as non-en
+  headers["accept-language"] = "en" // otherwise will spam console.logs with 404 and locale not found from API if your browser has its primary lang as non-en
+  
+  /*
+   * Main
+   */
+  
+  ;(async () => {
+    // cleanup
+    const outputPathDir = path.resolve(config.output.reportDirectory)
+    try {
+      await fs.remove(outputPathDir)
+    } catch (err) {
+      throw new Error(
+        `Could not remove directory on disk at path ${outputPathDir}`
+      )
+    }
+    try {
+      await fs.mkdirp(outputPathDir)
+    } catch (err) {
+      throw new Error(
+        `Could not create output directory on disk at path ${outputPathDir}`
+      )
+    }
+  
+    // wait until the site becomes accessible, before starting to run our tests
+    console.log(`Waiting for ${baseUrl} to become accessible...`)
+    const baseUrlAccessible = await new Promise(resolve => {
+      waitUntil(
+        config.waiting.interval * 1000,
+        Math.round(config.waiting.timeout / config.waiting.interval),
+        callback => {
+          axios
+            .get(baseUrl, { headers })
+            .then(response => {
+              callback(response.status === 200)
+            })
+            .catch(() => {
+              callback(false)
+            })
+        },
+        result => {
+          resolve(Boolean(result))
+        }
+      )
+    })
+  
+    if (!baseUrlAccessible) {
+      console.log(`${baseUrl} did not become accessible on time.`)
+      process.exit(1)
+    }
+  
+    console.log(`${baseUrl} is now accessible. Starting tests...`)
+  
+    // launch chrome
+    // console.log(`Launching Chrome...`)
+    const chromeOptions = {
+      chromeFlags: ["--headless", "--lang=en"],
+    }
+    const chrome = await chromeLauncher.launch({ chromeOptions })
+  
+    // connect to Puppeteer with Chrome
+    const resp = await util.promisify(request)(
+      `http://localhost:${chrome.port}/json/version`
+    )
+    const { webSocketDebuggerUrl } = JSON.parse(resp.body)
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: webSocketDebuggerUrl,
+    })
+  
+    // set cookies in Chrome
+    const parsedBaseUrl = url.parse(baseUrl)
+    const page = await browser.newPage()
+    if (headers.Cookie) {
+      // prepare the cookie prototype for our domain
+      const cookiePrototype = {
+        name: undefined,
+        value: undefined,
+        domain: "." + parsedBaseUrl.hostname,
+        path: "/",
+        httpOnly: false,
+        secure: false,
+      }
+  
+      // get the plain cookies
+      const plainCookies = cookie.parse(headers.Cookie)
+      delete headers.Cookie
+  
+      // create full cookie objects
+      let cookieJar = []
+      for (const [key, value] of Object.entries(plainCookies)) {
+        let concreteCookie = cookiePrototype
+        concreteCookie.name = key
+        concreteCookie.value = value
+  
+        cookieJar.push(concreteCookie)
+      }
+  
+      // set our cookies on the page
+      await page.setCookie(...cookieJar)
+    }
+  
+    // loop through the manifest, performing lighthouse tests
+    let overallPass = 1 // we will &= each audit against this, as a way of knowing if everying passed
+    let testResults = {} // we want to print the aggregate tests results at the end of everything, so we'll store the aggregate test results in here
+    for (let test of testGroup) {
+      const targetUrl = url.resolve(baseUrl, test.path)
+      const lighthouseConfig = test.config
+  
+      // lighthouse options
+      const lighthouseOptions = {
+        port: chrome.port,
+        logLevel: "error", // https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-logger/index.js#L79
+        output: "html",
+        extraHeaders: headers,
+        disableStorageReset: true,
+      }
+  
+      // set logging
+      log.setLevel(lighthouseOptions.logLevel)
+  
+      // run actual lighthouse test
+      // console.log(`[${targetUrl}] Running Lighthouse audit...`)
+      const lhResults = await lighthouse(
+        targetUrl,
+        lighthouseOptions,
+        lighthouseConfig
+      )
+      const lhJson = lhResults.lhr
+  
+      // store the report to disk
+      const sanitizedFilename = filenamify(targetUrl, { replacement: "_" })
+      const outputPath = path.resolve(
+        config.output.reportDirectory,
+        `${config.output.reportPrefix}${sanitizedFilename}.html`
+      )
+      try {
+        await fs.writeFileSync(outputPath, lhResults.report)
+      } catch (err) {
+        throw new Error(`Could not write report to disk at path ${outputPath}`)
+      }
+  
+      // process our results
+      // console.log(`[${targetUrl}] Processing output...`)
+  
+      // go through all the test and print to console
+      for (const [auditId, audit] of Object.entries(lhJson.audits)) {
+        if (audit.score == 0) {
+          console.log(
+            `[${targetUrl}] ❌ [${auditId}] ${audit.title} - ${audit.description}\n`
+          )
+        }
+      }
+  
+      // compare the thresholds
+      testResults[targetUrl] = []
+      for (const [category, minScore] of Object.entries(test.thresholds)) {
+        if (!lhJson.categories[category]) {
+          continue
+        }
+        const score = lhJson.categories[category].score
+        const pass = score >= minScore
+  
+        // combine this with the overall score. if any of our pass scores turns out false, then overallPass will end up false
+        overallPass &= pass
+  
+        // record the result
+        testResults[targetUrl].push({
+          pass,
+          category,
+          score,
+          minScore,
+        })
+      }
+    }
+  
+    // kill chrome
+    console.log(`Killing Chrome...`)
+    await chrome.kill()
+  
+    // print aggregate results
+    console.log("===============================\n")
+  
+    for (const [targetUrl, categoryResults] of Object.entries(testResults)) {
+      const tableData = []
+      tableData.push(["", "Audit".bold, targetUrl.bold])
+  
+      for (const categoryResult of categoryResults) {
+        const symbol = _(categoryResult.pass).thru(pass => {
+          if (pass) {
+            return " PASS ".bgGreen.black.bold
+          } else {
+            return " FAIL ".bgRed.white.bold
+          }
+        })
+        tableData.push([
+          symbol,
+          categoryResult.category,
+          `Score: ${categoryResult.score} (Threshold >= ${categoryResult.minScore})`,
+        ])
+      }
+  
+      console.log(table.table(tableData))
+    }
+  
+    // ultimately return an exit code. 0 if all pass, 1 otherwise
+    process.exit(
+      _(overallPass).thru(overallPass => {
+        if (overallPass == 1) {
+          return 0
+        } else {
+          return 1
+        }
+      })
+    )
+  })()
+  
+  // crash the process if we get any unhandled exceptions
+  process.on("unhandledRejection", up => {
+    throw up
+  })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3867,6 +3867,12 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
       "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g=="
     },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3910,6 +3916,26 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      },
+      "dependencies": {
+        "es6-promisify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "dev": true,
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        }
+      }
     },
     "airbnb-js-shims": {
       "version": "2.2.0",
@@ -4345,6 +4371,54 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axe-core": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.2.2.tgz",
+      "integrity": "sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "axobject-query": {
       "version": "2.0.2",
@@ -5317,6 +5391,16 @@
             "pify": "^3.0.0"
           },
           "dependencies": {
+            "filenamify": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+              "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+              "requires": {
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.0",
+                "trim-repeated": "^1.0.0"
+              }
+            },
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -6088,6 +6172,19 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
+    "chrome-launcher": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.7.tgz",
+      "integrity": "sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "is-wsl": "^1.1.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "^2.6.1"
+      }
+    },
     "chrome-trace-event": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -6364,8 +6461,7 @@
     "colors": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "optional": true
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -7323,6 +7419,21 @@
         }
       }
     },
+    "cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+      "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
     "csstype": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
@@ -7679,6 +7790,12 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "details-element-polyfill": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/details-element-polyfill/-/details-element-polyfill-2.2.0.tgz",
+      "integrity": "sha512-Sjg+A4q3Mrn2JKQu58zsreuHqAb4M0qe4eK5ZQAIBuch9i8nx6MlKWCxx0z8s59MMen9I4WXavzW5z+BnkIC0A==",
+      "dev": true
+    },
     "detect-indent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
@@ -7950,6 +8067,16 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+        },
+        "filenamify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+          "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+          "requires": {
+            "filename-reserved-regex": "^2.0.0",
+            "strip-outer": "^1.0.0",
+            "trim-repeated": "^1.0.0"
+          }
         },
         "got": {
           "version": "7.1.0",
@@ -8248,6 +8375,12 @@
       "version": "4.5.13",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.13.tgz",
       "integrity": "sha512-xi6hh6gsvDE0MaW4Vp1lgNEBpVcCXRWfPXj5egDvtgLz4L9MEvNwYEMdJH+JJinWkwa8c3c3o5HduV7dB/e1Hw==",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
@@ -8947,6 +9080,53 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "fd-slicer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+          "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+          "dev": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+          "dev": true,
+          "requires": {
+            "fd-slicer": "~1.0.1"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -9120,12 +9300,13 @@
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
-      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
+      "integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
+      "dev": true,
       "requires": {
         "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.0",
+        "strip-outer": "^1.0.1",
         "trim-repeated": "^1.0.0"
       }
     },
@@ -9379,13 +9560,22 @@
       "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
     },
     "fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+          "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+          "dev": true
+        }
       }
     },
     "fs-minipass": {
@@ -10102,6 +10292,16 @@
             "locate-path": "^3.0.0"
           }
         },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "gatsby-cli": {
           "version": "2.7.7",
           "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.7.7.tgz",
@@ -10520,6 +10720,16 @@
         "xstate": "^3.1.0"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "got": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -11021,6 +11231,12 @@
         }
       }
     },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
+    },
     "has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
@@ -11302,6 +11518,12 @@
         }
       }
     },
+    "http-link-header": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-0.8.0.tgz",
+      "integrity": "sha1-oitBoMmx4tj6wb8baXxr1TLV9eQ=",
+      "dev": true
+    },
     "http-parser-js": {
       "version": "0.4.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
@@ -11342,6 +11564,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -11400,6 +11632,12 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+    },
+    "image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha1-g7Qsei5uS4VQVHf+aRf128VkIOU=",
+      "dev": true
     },
     "imagemin": {
       "version": "6.1.0",
@@ -11784,6 +12022,29 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "intl-messageformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
+      "dev": true,
+      "requires": {
+        "intl-messageformat-parser": "1.4.0"
+      },
+      "dependencies": {
+        "intl-messageformat-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+          "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=",
+          "dev": true
+        }
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.8.0.tgz",
+      "integrity": "sha512-Mb4oWtUbMKeri20kDmhGwtE54gjV2gtKWZSEdKo3dztxhCwrZdMWorzSzq6n59DX2CjZJrGtsSDVbrmhubsBpA==",
       "dev": true
     },
     "into-stream": {
@@ -12370,6 +12631,12 @@
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
     },
+    "js-library-detector": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-5.4.0.tgz",
+      "integrity": "sha512-lSTEC9Q3L/cXOhYIilW3GH/v4tOnPIN40NTIBHRcn2vxTwGhMyySQTQpJ0W68ISGzOgvwVe7KCfQ9PJi6MsOIw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12454,6 +12721,28 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonld": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.6.2.tgz",
+      "integrity": "sha512-eMzFHqhF2kPMrMUjw8+Lz9IF1QkrxTOIfVndkP/OpuoZs31VdDtfDs8mLa5EOC/ROdemFTQGLdYPZbRtmMe2Yw==",
+      "dev": true,
+      "requires": {
+        "rdf-canonize": "^1.0.2",
+        "request": "^2.88.0",
+        "semver": "^5.6.0",
+        "xmldom": "0.1.19"
+      }
+    },
+    "jsonlint-mod": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/jsonlint-mod/-/jsonlint-mod-1.7.4.tgz",
+      "integrity": "sha512-FYOkwHqiuBbdVCHgXYlmtL+iUOz9AxCgjotzXl+edI0Hc1km1qK6TrBEAyPpO+5R0/IX3XENRp66mfob4jwxow==",
+      "dev": true,
+      "requires": {
+        "JSV": ">= 4.0.x",
+        "nomnom": ">= 1.5.x"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -12577,6 +12866,220 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "lighthouse": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-5.1.0.tgz",
+      "integrity": "sha512-T+6VYefgRgSRHCgWhSQzsS1Jyu6JJ5I3cnrH/Q7BvwoJwnMhHME+JQ4ib5Oek2ZTfOakoarLDqrFPDtYNxk0KA==",
+      "dev": true,
+      "requires": {
+        "axe-core": "3.2.2",
+        "chrome-launcher": "^0.10.7",
+        "configstore": "^3.1.1",
+        "cssstyle": "1.2.1",
+        "details-element-polyfill": "2.2.0",
+        "http-link-header": "^0.8.0",
+        "inquirer": "^3.3.0",
+        "intl-messageformat": "^2.2.0",
+        "intl-messageformat-parser": "^1.4.0",
+        "jpeg-js": "0.1.2",
+        "js-library-detector": "^5.4.0",
+        "jsonld": "^1.5.0",
+        "jsonlint-mod": "^1.7.4",
+        "lighthouse-logger": "^1.2.0",
+        "lodash.isequal": "^4.5.0",
+        "lookup-closest-locale": "6.0.4",
+        "metaviewport-parser": "0.2.0",
+        "mkdirp": "0.5.1",
+        "opn": "4.0.2",
+        "parse-cache-control": "1.0.1",
+        "raven": "^2.2.1",
+        "rimraf": "^2.6.1",
+        "robots-parser": "^2.0.1",
+        "semver": "^5.3.0",
+        "speedline-core": "1.4.2",
+        "update-notifier": "^2.5.0",
+        "ws": "3.3.2",
+        "yargs": "3.32.0",
+        "yargs-parser": "7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "jpeg-js": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
+          "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
+          "dev": true
+        },
+        "opn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "ws": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
+          "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "lighthouse-logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "lines-and-columns": {
@@ -12749,6 +13252,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -12892,6 +13401,12 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
+    "lookup-closest-locale": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.0.4.tgz",
+      "integrity": "sha512-bWoFbSGe6f1GvMGzj17LrwMX4FhDXDwZyH04ySVCPbtOJADcSRguZNKewoJ3Ful/MOxD/wRHvFPadk/kYZUbuQ==",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13018,6 +13533,12 @@
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
+    },
+    "marky": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+      "integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
+      "dev": true
     },
     "md5": {
       "version": "2.2.1",
@@ -13225,6 +13746,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+    },
+    "metaviewport-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
+      "integrity": "sha1-U1w84cz2IjpQJf3cahw2UF9+fbE=",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -13661,6 +14188,41 @@
       "integrity": "sha512-wym2jptfuKowMmkZsfCSTsn8qAVo8zm+UiQA6l5dNqUcpfChZSnS/vbbpOeXczf+VdPhutxh+99lWHhdd6xKzg==",
       "requires": {
         "semver": "^5.3.0"
+      }
+    },
+    "nomnom": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "dev": true,
+      "requires": {
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        }
       }
     },
     "noms": {
@@ -14249,6 +14811,12 @@
         "xml-parse-from-string": "^1.0.0",
         "xml2js": "^0.4.5"
       }
+    },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
+      "dev": true
     },
     "parse-entities": {
       "version": "1.2.2",
@@ -15363,6 +15931,12 @@
         "ipaddr.js": "1.9.0"
       }
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -15374,9 +15948,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
-      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -15425,6 +15999,33 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "puppeteer": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.18.1.tgz",
+      "integrity": "sha512-luUy0HPSuWPsPZ1wAp6NinE0zgetWtudf5zwZ6dHjMWfYpTQcmKveFRox7VBNhQ98OjNA9PQ9PzQyX8k/KrxTg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -15495,6 +16096,27 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
+    "raven": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
+      "dev": true,
+      "requires": {
+        "cookie": "0.3.1",
+        "md5": "^2.2.1",
+        "stack-trace": "0.0.10",
+        "timed-out": "4.0.1",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+          "dev": true
+        }
+      }
+    },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
@@ -15527,6 +16149,24 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      }
+    },
+    "rdf-canonize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.3.tgz",
+      "integrity": "sha512-piLMOB5Q6LJSVx2XzmdpHktYVb8TmVTy8coXJBFtdkcMC96DknZOuzpAYqCWx2ERZX7xEW+mMi8/wDuMJS/95w==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^0.8.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+          "dev": true
+        }
       }
     },
     "react": {
@@ -16536,6 +17176,12 @@
         "inherits": "^2.0.1"
       }
     },
+    "robots-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-2.1.1.tgz",
+      "integrity": "sha512-6yWEYSdhK3bAEcYY0In3wgSBK70BiQoJArzdjZKCP/35b3gKIYu5Lc0qQqsoxjoLVebVoJiKK4VWGc5+oxvWBQ==",
+      "dev": true
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -17503,6 +18149,25 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        }
+      }
+    },
+    "speedline-core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.2.tgz",
+      "integrity": "sha512-9/5CApkKKl6bS6jJ2D0DQllwz/1xq3cyJCR6DLgAQnkj5djCuq8NbflEdD2TI01p8qzS9qaKjzxM9cHT11ezmg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.1.2"
+      },
+      "dependencies": {
+        "jpeg-js": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
+          "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
+          "dev": true
         }
       }
     },
@@ -18631,6 +19296,12 @@
         }
       }
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
     "unbzip2-stream": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
@@ -18655,6 +19326,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -19136,6 +19813,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
+    },
+    "wait-until": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wait-until/-/wait-until-0.0.2.tgz",
+      "integrity": "sha1-eoq671WQ2XD9RGl9Q2tXYePq7b4=",
+      "dev": true
     },
     "warning": {
       "version": "3.0.0",
@@ -19686,6 +20369,12 @@
         "string-width": "^2.1.1"
       }
     },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true
+    },
     "with-open-file": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.6.tgz",
@@ -20003,6 +20692,12 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xmldom": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -35,15 +35,27 @@
     "@types/react-helmet": "^5.0.8",
     "@types/storybook__react": "^4.0.2",
     "@types/styled-components": "^4.1.16",
+    "axios": "^0.19.0",
     "babel-loader": "^8.0.6",
+    "chrome-launcher": "^0.10.7",
+    "colors": "^1.3.3",
+    "cookie": "^0.4.0",
+    "filenamify": "^4.1.0",
+    "fs-extra": "^8.1.0",
+    "lighthouse": "^5.1.0",
     "prettier": "^1.18.2",
+    "puppeteer": "^1.18.1",
+    "request": "^2.88.0",
+    "table": "^5.4.1",
     "tslint": "^5.18.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-loader": "^3.5.4",
     "tslint-plugin-prettier": "^2.0.1",
     "tslint-react": "^4.0.0",
-    "typescript": "^3.5.2"
+    "typescript": "^3.5.2",
+    "valid-url": "^1.0.9",
+    "wait-until": "0.0.2"
   },
   "keywords": [
     "appnroll"
@@ -58,7 +70,9 @@
     "type-check": "tsc --noEmit",
     "lint": "tslint --project .",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "test:lighthouse": "node ./lighthouse/runner.js ./lighthouse/manifest.js",
+    "test:lighthouse:serve": "node ./lighthouse/runner.js ./lighthouse/manifest.js http://localhost:9000 local"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* `npm run build` creates `lighthouse-pages.json` in form of JSON: `["/","/404.html"]` (example) against which lighthouse audit will run
* you can provide it manually if necessary
* after build, run `npm run serve` so that the page is accessible 
* finally, run `test:lighthouse:serve` to run reports

For custom cases, `test:lighthouse (server address) (public|local)` may be used.
`local` skips `["is-on-https", "uses-http2", "robots-txt"]` those audits (for example, http requests instead of https. `public` should be used as black box/regular tests against deployed application.

`Performance` category is skipped as it was giving non-accurate results but we may want to consider using it in particular project.